### PR TITLE
Fixing a problem in pattern matching of derivative of large functions

### DIFF
--- a/diff.lua
+++ b/diff.lua
@@ -256,11 +256,12 @@ local f, dn = f, dn
 | end
 | args = concat(args, ",")
 return function(${args})
-| local dargs = args
+| local dargs = args..","
 | for i=1,#dxi do
 |   local dx = dxi[i]
-|   dargs = dargs:gsub("x"..dx, "dn(x"..dx..",0)")
+|   dargs = dargs:gsub("x"..dx..",", "dn(x"..dx..",0),")
 | end
+| dargs = dargs:gsub(",$", "")
 | local retadj = { } 
 | for i=1,#dxi do
 | local from, to = "dn%(x"..dxi[i]..",0%)", "dn%(x"..dxi[i]..",1%)"


### PR DESCRIPTION
Fixing a problem in pattern matching where the derivative of functions with 10 or more variables fails.

For example, the following code does not work without the fix:

``` lua
math = require("sci.math").generic
diff = require("sci.diff")

function func(a, b, c, d, e, f, g, i, j, k, l)
    return a + b + c + d + e + f + g + i + j + k + l
end

df = diff.derivativef(func, 11)
```

The problem happens because x10, x11, ... are matched as x1 (I believe this also would happen with x20, x21, ... and x2).

This fix adds an extra comma to ensure that the full numbers are matched, and then removes the comma afterwards.
